### PR TITLE
Optional clean up build env

### DIFF
--- a/docs/install/linux.mdx
+++ b/docs/install/linux.mdx
@@ -194,7 +194,7 @@ If you run the command specified in the next step, this will be included automat
 
 * Install the required linux packages:
   * On **Ubuntu/Debian** run `sudo apt update && sudo apt install build-essential git wl-clipboard libxkbcommon-dev libdbus-1-dev libwxgtk3.0-gtk3-dev libssl-dev`
-  * On **Fedora** run `sudo dnf install @development-tools gcc-c++ wl-clipboard libxkbcommon-devel dbus-devel wxGTK3-devel`
+  * On **Fedora** run `sudo dnf install @development-tools gcc-c++ wl-clipboard libxkbcommon-devel dbus-devel wxGTK3-devel openssl-devel`
 * Espanso heavily relies on [cargo make](https://github.com/sagiegurari/cargo-make) for the various packaging
 steps. You can install it by running:
 
@@ -229,5 +229,12 @@ sudo mv target/release/espanso /usr/local/bin/espanso
 ```
 
 The process is almost complete, you just need to grant the required capabilities.
+
+#### Clean up build environment (optional)
+
+If you don't do development in rust and C++ etc., you can remove the development packages (and replace with standard packages):
+
+* On **Ubuntu/Debian** run `sudo apt remove build-essential git wl-clipboard libxkbcommon-dev libdbus-1-dev libwxgtk3.0-gtk3-dev libssl-dev && sudo apt install libwxgtk3.0-gtk3`
+* On **Fedora** run `sudo dnf remove @development-tools gcc-c++ wl-clipboard libxkbcommon-devel dbus-devel wxGTK3-devel openssl-devel && sudo dnf install wxGTK3`
 
 <WaylandFinalSteps />


### PR DESCRIPTION
- Added missing openssl-devel for Fedora Wayland install
- Added how to clean up build env but leave espanso working