### PR TITLE
Uses Windows-provided environment variables for config path

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -97,7 +97,7 @@ reside in the `espanso` directory, whose location depends on the current OS:
 * macOS: `$HOME/Library/Application Support/espanso` (e.g. `/Users/user/Library/Application Support/espanso`)
   * NOTE: when migrating from the previous 0.7.3 version, the configuration directory will be located in
   `$HOME/Library/Preferences/espanso` for compatibility purposes.
-* Windows: `{FOLDERID_RoamingAppData}\espanso` (e.g. `C:\Users\user\AppData\Roaming\espanso`)
+* Windows: `%APPDATA%\espanso` (e.g. `C:\Users\user\AppData\Roaming\espanso`)
 
 A quick way to find the path of your configuration folder is by using the following command:
 


### PR DESCRIPTION
Makes it slightly easier to locate config directory in File Explorer