### PR TITLE
add mention of word_separators config opt in Word Triggers

### DIFF
--- a/docs/matches/basics.md
+++ b/docs/matches/basics.md
@@ -189,6 +189,9 @@ Before | After |
 Is ther anyone else? | Is there anyone else? | `ther` is converted to `there`
 I have other interests | I have other interests | `other` is left unchanged
 
+The [configuration option](/docs/configuration/options/) `word_separators` may
+be used to customize which characters qualify as word separators.
+
 ## Case propagation
 
 Espanso also supports *case-propagation*, which makes it possible to expand a match


### PR DESCRIPTION
I only found out about `word_separators` by looking at Espanso issues and finding this comment: https://github.com/espanso/espanso/issues/1411#issuecomment-1289617358

This PR adds a quick mention of the config option and a link to the configuration options page. 