### PR TITLE
Add notes to script extension

### DIFF
--- a/docs/matches/extensions.mdx
+++ b/docs/matches/extensions.mdx
@@ -338,6 +338,13 @@ any lag.
 
 :::
 
+Other notes:
+
+* Keep in mind that you can't pass arguments this way, so if your script relies on an `$ESPANSO_foo` environment variable
+    you need to read it from within your script instead of as an argument (e.g. in Python do `import os; os.environ['ESPANSO_NUM1']`
+    not `sys.argv[1:][0]`)
+* Even though it's possible to invoke your script from the Shell extension, prefer the script extension because it is faster.
+
 ### Useful Environment Variables
 
 When triggering the shell command, Espanso also injects a few useful Environment Variables that you can use:


### PR DESCRIPTION
I was invoking a script from the shell extension because it was the first way I figured out how to pass arguments into my script (e.g. `cmd: python foo.py $ESPANSO_NUM1`)

Performance was lousy, with a 1-3 second lag for a script that only took 200-300ms to execute.

Switching to the script extension and using a environmental variable instead of command line argument was much faster.

These docs may help the next person.

<img width="999" alt="image" src="https://user-images.githubusercontent.com/2789593/218326946-1f9e56c9-7de7-433c-9bda-264c59e3bc1f.png">
