### PR TITLE
Added security section for the documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE (VS Code)
+.vscode
+
 # Dependencies
 /node_modules
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,69 @@
+---
+sidebar_position: 6
+title: Security
+---
+
+> TODO: this document is relative to version 1 and will be updated soon for changes introduced in version 2
+>
+> Despite significant architectural differences, the following points are still a good approximation
+> of the internals.
+
+Espanso has always been designed with a strong focus on security. 
+In the following section, there is an overview of the critical security
+components.
+
+If you have any doubt, don't hesitate to contact me.
+
+## Architecture and Safety
+
+In its most basic form, a text expander is composed of two parts:
+
+* A **global key detector** this intercepts keys pressed by the user, 
+in order to determine if a trigger was typed.
+
+* A **key injection mechanism** that injects the
+final text into the current application, a process known as *expansion*.
+
+At this point, some of you may think that espanso is acting as a **keylogger**,
+due to the *global key detector* we mentioned before. The good news is, **it's not!**
+
+While espanso detects key presses as a keylogger would do,
+**it doesn't log anything**. Moreover, to further reduce risks, espanso only
+stores in memory the last 3 chars by default (you can change this amount by
+setting the `backspace_limit` parameter in the config) and this is needed
+to allow the user to correct wrongly typed triggers by pressing backspace,
+up to 3 characters.
+
+
+<!-- TODO: this section is outdated, so right now I commented it out.
+
+ The matching part is implemented with an efficient [data structure](https://github.com/federico-terzi/espanso/blob/master/src/matcher/scrolling.rs) 
+that keeps track of the compatible matches in a “rolling” basis. So that in the worst case scenario,
+the longest sequence of chars kept in memory would be equal to the longest trigger. -->
+
+And of course, if you don't trust me you can examine all the code! That's
+the wonderful thing about open source :)
+
+### Implementation
+
+The *global key detector* uses various OS-dependent APIs, in particular:
+
+* On Windows, it uses the [RawInput API](https://docs.microsoft.com/en-us/windows/win32/inputdev/raw-input).
+* On macOS, it uses [addGlobalMonitorForEvents](https://developer.apple.com/documentation/appkit/nsevent/1535472-addglobalmonitorforevents).
+* On Linux, it uses the [X Record Extension](https://www.x.org/releases/X11R7.6/doc/libXtst/recordlib.html).
+
+## Reporting Security Issues
+
+To report a security issue, please email me at federicoterzi96[at]gmail.com
+
+## Secure Input 
+
+:::tip For Linux and Windows users
+
+ This feature is only available on macOS.
+
+:::
+
+If you are running espanso on macOS another security feature called secure input is active. 
+This feature disables all applications from using accessibility features when entering information in secure fields.
+As you can imagine this is great for security, on the other hand this might break things, if you are encountering issues [have a look here](/docs/troubleshooting/secure-input).


### PR DESCRIPTION
As mentioned in #18 it would be nice to have a security section for espanso, also explaining why this is not a keylogger. I also added a small note to secure input and commented out the architecture section that was linking to a non-existing gist. 

I think this is a good first start to add for security that could be updated later.

Also added .vscode to the gitignore.