### PR TITLE
Update linux.mdx for Fedora Wayland compilation

### DIFF
--- a/docs/install/linux.mdx
+++ b/docs/install/linux.mdx
@@ -194,7 +194,7 @@ If you run the command specified in the next step, this will be included automat
 
 * Install the required linux packages:
   * On **Ubuntu/Debian** run `sudo apt update && sudo apt install build-essential git wl-clipboard libxkbcommon-dev libdbus-1-dev libwxgtk3.0-gtk3-dev libssl-dev`
-  * On **Fedora** run `sudo dnf install @development-tools gcc-c++ wl-clipboard libxkbcommon-devel dbus-devel wxGTK3-devel`
+  * On **Fedora** run `sudo dnf install @development-tools gcc-c++ wl-clipboard libxkbcommon-devel dbus-devel wxGTK-devel.x86_64`
 * Espanso heavily relies on [cargo make](https://github.com/sagiegurari/cargo-make) for the various packaging
 steps. You can install it by running:
 


### PR DESCRIPTION
Minor update:
Changed "wxGTK3-devel" (unavailable) to "wxGTK-devel.x86_64" to install wx-config.