### PR TITLE
Correct Windows' mklink instructions

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -40,13 +40,13 @@ Make sure to replace it with the actual path, determined in the previous section
 For example, if you see this command:
 
 ```
-mklink /J "$CONFIG" "C:\Users\user\Dropbox\espanso"
+mklink /J "C:\Users\user\Dropbox\espanso" "$CONFIG"
 ```
 
 You should run something like:
 
 ```
-mklink /J "C:\Users\user\AppData\Roaming\espanso" "C:\Users\user\Dropbox\espanso"
+mklink /J "C:\Users\user\Dropbox\espanso" "C:\Users\user\AppData\Roaming\espanso"
 ```
 
 :::
@@ -64,7 +64,7 @@ C:\Users\user\Dropbox\espanso
 Now you need to create a **symbolic link**. Open the Command Prompt and type the following command, making sure you specify the correct paths:
 
 ```
-mklink /J "$CONFIG" "C:\Users\user\Dropbox\espanso"
+mklink /J "C:\Users\user\Dropbox\espanso" "$CONFIG"
 ```
 
 Now restart Espanso and you should be ready to go!


### PR DESCRIPTION
From discord discussion starting: https://discord.com/channels/884163483409731584/1013916843175587900/1199814909085634750, the Windows' mklink commands are the wrong way round.