### PR TITLE
Fix symlink creation example for Win in sync.md

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -40,13 +40,13 @@ Make sure to replace it with the actual path, determined in the previous section
 For example, if you see this command:
 
 ```
-mklink /J "C:\Users\user\Dropbox\espanso" "$CONFIG"
+mklink /J "$CONFIG" "C:\Users\user\Dropbox\espanso"
 ```
 
 You should run something like:
 
 ```
-mklink /J "C:\Users\user\Dropbox\espanso" "C:\Users\user\AppData\Roaming\espanso"
+mklink /J "C:\Users\user\AppData\Roaming\espanso" "C:\Users\user\Dropbox\espanso"
 ```
 
 :::
@@ -76,7 +76,7 @@ C:\Users\user\Dropbox\espanso
 Now you need to create a **symbolic link**. Open the Command Prompt and type the following command, making sure you specify the correct paths:
 
 ```
-mklink /J "C:\Users\user\Dropbox\espanso" "$CONFIG"
+mklink /J "$CONFIG" "C:\Users\user\Dropbox\espanso"
 ```
 
 Now restart Espanso and you should be ready to go!


### PR DESCRIPTION
The order of `mklink` arguments is inverse comparing to `ln`:

![image](https://github.com/espanso/website/assets/6697626/6ccb7fd6-76c3-45cd-a031-d9a460554c7f)
