### PR TITLE
Use "menu bar" and "system tray" to describe icon location

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -108,7 +108,7 @@ search_trigger: off
 
 ## Hiding the Icon
 
-You can hide the Espanso status icon on macOS and Windows by adding the following option to 
+You can hide the Espanso status icon on the macOS menu bar or the Windows system tray by adding the following option to 
 your `$CONFIG/config/default.yml` file:
 
 ```yaml title="$CONFIG/config/default.yml"


### PR DESCRIPTION
I spent quite a while searching for various combinations of "espanso" and "menu bar" across search engines and GitHub before I found the `show_icon` configuration option.  I thought including the phrase in the docs would make it more likely that someone searching for this option would find it.