### PR TITLE
Fix callout formatting issue

### DIFF
--- a/docs/matches/extensions.mdx
+++ b/docs/matches/extensions.mdx
@@ -364,7 +364,9 @@ but be aware that Windows has an 8191 character limit on these.
 :::caution a note about performance
 
 Because of the execution time, you should limit yourself to fast-running scripts
-to avoid any lag. :::
+to avoid any lag.
+
+:::
 
 ### Useful Environment Variables
 


### PR DESCRIPTION
Fix a callout that was not formatted properly, causing the entirety of the rest of the page layout to be affected.