### PR TITLE
Gist

### DIFF
--- a/docs/matches/basics.md
+++ b/docs/matches/basics.md
@@ -127,9 +127,9 @@ In the remaining lines we declared the **parameters** used by the extension, in 
 
 Normally Espanso follows the `backend` settings specified in `default.yml`, the default for which (`Auto`) is to use the Inject mechanism for short replacements, and Clipboard for longer ones. 
 
-The `force_mode: clipboard` or `force_mode: keys` properties override this for an individual match, and may be useful in particular environments.
+When that doesn't work, the `force_mode: clipboard` or `force_mode: keys` properties override it for an individual match, and are useful for testing the mechanisms within particular programs.
 
-If you find yourself needing them widely, however, an [app-specific configuration](../../configuration/app-specific-configurations), or a global [configuration](../../configuration/options/#options-reference) change to the `backend` value in `default.yml` may be more convenient.
+If you find yourself needing them, however, an [app-specific configuration](../../configuration/app-specific-configurations), or a global [configuration](../../configuration/options/#options-reference) change to the `backend` value in `default.yml` is likely to be required.
 
 ## Global Variables
 

--- a/docs/matches/extensions.mdx
+++ b/docs/matches/extensions.mdx
@@ -94,7 +94,7 @@ matches:
 ```
 
 The `locale` parameter must be specified in the BCP47 format.
-You can find a list of the available locales [here](https://gist.github.com/federico-terzi/b6465dfcca47e86e9ef0eb597ff6f2e9).
+You can find a list of the available locales [here](https://gist.github.com/typpo/b2b828a35e683b9bf8db91b5404f1bd1).
 
 ## Choice Extension
 


### PR DESCRIPTION
Removal of the link to our BCP47 gist in favour of a link to the (more actively maintained) original gist by @typpo - if you agree. As discussed in https://github.com/espanso/website/pull/25. After this, our gist can be removed.

Minor rewording in basics.md regarding injection mechanisms.