### PR TITLE
Various

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -87,10 +87,8 @@ Espanso uses a **file-based configuration** approach, following the Unix philoso
 reside in the `espanso` directory, whose location depends on the current OS:
 
 * Linux: `$XDG_CONFIG_HOME/espanso` (e.g. `/home/user/.config/espanso`)
-* macOS: `$HOME/Library/Application Support/espanso` (e.g. `/Users/user/Library/Application Support/espanso`)
-  * NOTE: when migrating from the previous 0.7.3 version, the configuration directory will be located in
-  `$HOME/Library/Preferences/espanso` for compatibility purposes.
 * Windows: `{FOLDERID_RoamingAppData}\espanso` (e.g. `C:\Users\user\AppData\Roaming\espanso`)
+* macOS: `$HOME/Library/Application Support/espanso` (e.g. `/Users/user/Library/Application Support/espanso`). You can use `$HOME/.config/espanso` instead, but you'll need to move the folders there yourself, while Espanso is stopped.
 
 A quick way to find the path of your configuration folder is by using the following command:
 

--- a/docs/matches/extensions.mdx
+++ b/docs/matches/extensions.mdx
@@ -418,7 +418,9 @@ When triggering the shell command, Espanso also injects a few useful Environment
 For more information, check out the [Variables](../variables) section.
 
 ### UTF-8 characters
-By default, some scripts and shell expansions don't return UTF-8 characters, which can interfere with those generating foreign-language letters. A solution for Python scripts is to include the following in the script:
+By default, some scripts and shell expansions don't return UTF-8 characters, which can interfere with those generating foreign-language letters. 
+
+A solution for Python scripts is to include the following in the script:
 ```py
 import sys
 sys.stdout.reconfigure(encoding='utf-8')
@@ -427,6 +429,17 @@ For PowerShell:
 ```powershell
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 ```
+For HTML:
+```html
+html: |
+  <meta charset="UTF-8">
+```
+For Bash:
+```bash
+cmd: |
+  export LANG='cs_CZ.UTF-8'
+```      
+using your `locale` language setting.
 
 ## Shell Extension
 

--- a/src/pages/versions.md
+++ b/src/pages/versions.md
@@ -7,5 +7,5 @@ title: Versions
 There is now just one version available following removal of the legacy version 0.7.3:
 
 - The [v2 version](/docs/get-started/) is a brand new rewrite with many new features and improvements.
-  We recommend all new users to use this version, as the previous one is not being actively maintained anymore.
+  We recommend all new users to use this version, as the previous one is not being actively maintained any more.
 

--- a/src/pages/versions.md
+++ b/src/pages/versions.md
@@ -6,6 +6,5 @@ title: Versions
 
 There is now just one version available following removal of the legacy version 0.7.3:
 
-- The [v2 version](/docs/get-started/) is a brand new rewrite with many new features and improvements.
-  We recommend all new users to use this version, as the previous one is not being actively maintained any more.
+- The [v2 version](/docs/get-started/) is a rewrite with many improvements and new features. We recommend all new users use this version, as the previous one is no longer supported or maintained.
 


### PR DESCRIPTION
`get-started.md`: addition of alternative location for macOS Espanso folders
`extensions.mdx`: more notes on returning UTF-8 characters
`versions.md`: minor rewording