### PR TITLE
Update MacOS homebrew installation guide

### DIFF
--- a/docs/install/mac.mdx
+++ b/docs/install/mac.mdx
@@ -24,14 +24,6 @@ After you've downloaded the archive, uncompress it and move it into your `/Appli
 
 Espanso can also be installed through [Homebrew](https://brew.sh/), a popular macOS package manager.
 
-However, because Espanso is hosted outside the core Homebrew repository, and to be sure of downloading the latest version, you may prefer to first add the project _tap_ by running the following command inside a terminal:
-
-```
-brew tap espanso/espanso
-```
-
-Either way, you can then install Espanso by running the following command:
-
 ```
 brew install espanso
 ```

--- a/docs/install/mac.mdx
+++ b/docs/install/mac.mdx
@@ -32,11 +32,17 @@ If the process succeeds, you'll find an Espanso app inside your `/Applications` 
 
 :::info Users coming from version 0.7.3
 
-If you're coming from version 0.7.3 or earlier, you'll need to remove the previous Homebrew tap
-first with the following command:
+If you're coming from an older version of Espanso installed via Homebrew, you may need to remove the
+previous Homebrew tap first with the following command:
 
 ```
 brew untap federico-terzi/espanso
+```
+
+or 
+
+```
+brew untap espanso/espanso
 ```
 
 :::


### PR DESCRIPTION
Espanso is in the [official homebrew-cask repository](https://github.com/Homebrew/homebrew-cask/blame/master/Casks/e/espanso.rb). Users can install Espanso via Homebrew without tapping the [homebrew-espanso](https://github.com/espanso/homebrew-espanso) tap.

This small PR updates the documentation with streamlined instructions for installing Espanso via Homebrew.

Resolves #95.