### PR TITLE
Revert "Mac M1 link download fixed"

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -28,7 +28,7 @@ For example:
 ```bash
 espanso --config_dir /path/to/your/files start --unmanaged
 ```
-For Windows it may be necessary to use an `espanso ... launcher` command instead.
+For Windows it may be necessary to use an `espanso launcher` command instead.
 
 :::caution
 If you're already running Espanso as a service, stop it first with `espanso stop` and `espanso service unregister`.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -121,7 +121,7 @@ module.exports = {
     MAC_INTEL_DOWNLOAD_URL:
       "https://github.com/espanso/espanso/releases/download/{{{VERSION}}}/Espanso-Mac-Intel.zip",
     MAC_M1_DOWNLOAD_URL:
-      "https://github.com/espanso/espanso/releases/download/{{{VERSION}}}/Espanso-Mac-M1.dmg",
+      "https://github.com/espanso/espanso/releases/download/{{{VERSION}}}/Espanso-Mac-M1.zip",
     WIN_INSTALLER_DOWNLOAD_URL:
       "https://github.com/espanso/espanso/releases/download/{{{VERSION}}}/Espanso-Win-Installer-x86_64.exe",
     WIN_PORTABLE_DOWNLOAD_URL:


### PR DESCRIPTION
Reverts espanso/website#105

We did a mistake there. The problem was that the version is locked in this line [here](https://github.com/espanso/website/blob/bd376cbe237042c3d63f8f2e8e660ea23a4e7c40/docusaurus.config.js#L4)

Also, there is another issue, in that the version is not correct, but that is part of another PR #102 .

The release v2.2.3 doesn't have the mac intel files

To complicate the problem even more, if we choose v2.2.4, it doesn't have a windows files (nor portable or installable).

So, after 2.2.1,  we don't have any version with
- mac intel,
- mac silicon,
- windows portable,
- windows installable,
- linux (various)
