### PR TITLE
Changes the Debian (and relatives) install command to avoid warning

### DIFF
--- a/docs/install/linux.mdx
+++ b/docs/install/linux.mdx
@@ -58,7 +58,7 @@ in the file `espanso-debian-x11-amd64-sha256.txt`
 You can now install the package using:
 
 ```
-sudo apt install ./espanso-debian-x11-amd64.deb
+sudo dpkg -i ./espanso-debian-x11-amd64.deb
 ```
 
 <X11AfterInstall />


### PR DESCRIPTION
On my installation of Linux Mint 22.2 Cinnamon (X11) I encountered the following warning when using 'sudo apt install'

```
╰─$ sudo apt install ./espanso-debian-x11-amd64.deb
[sudo] password for marcus:                
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'espanso' instead of './espanso-debian-x11-amd64.deb'
The following NEW packages will be installed
  espanso
0 to upgrade, 1 to newly install, 0 to remove and 7 not to upgrade.
Need to get 0 B/3,898 kB of archives.
After this operation, 14.4 MB of additional disk space will be used.
Get:1 /home/marcus/Downloads/espanso-debian-x11-amd64.deb espanso amd64 2.2.7-1 [3,898 kB]
Selecting previously unselected package espanso.
(Reading database ... 803375 files and directories currently installed.)
Preparing to unpack .../espanso-debian-x11-amd64.deb ...
Unpacking espanso (2.2.7-1) ...
Setting up espanso (2.2.7-1) ...
N: Download is performed unsandboxed as root, as file '/home/marcus/Downloads/espanso-debian-x11-amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
```

I don't fully understand the reason, but it is more usual to use `sudo dkpg -i` when installing a downloaded .deb from the local disk, and this is what I generally see in other software.

This PR simply changes the command to `sudo dpkg -i`. I have tested this on my machine by uninstalling the package that was originally installed by `apt` and reinstalling this way, and it seems to work without the warning.

Great work on `espanso` BTW - I look forward to using it!