### PR TITLE
Various v2.3.0 additions

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -107,7 +107,8 @@ show_notifications: false
 
 Here are lists of all the available options.
 
-### The first list contains options which can _only_ be defined inside the `$CONFIG/config/default.yml` file:
+### `default.yml` only
+The first list contains options which can _only_ be defined inside the `$CONFIG/config/default.yml` file:
 
 Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default
 --- 	 | 	 --- 	 | 	 --- 	 | 	 ---
@@ -125,7 +126,8 @@ Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default
 `word_separators` 	 | 	 Chars that when pressed mark the start and end of a word. Examples of this are . or , 	 | 	 A sequence of strings 	 | 	 `[" ", ",", ".", "?", "!", "\r", "\n", "\t", "'", "\"", "\x0c", "(", ")", "[", "]", "{", "}", "<", ">", ":", ";", "\xa0"]` 	 | 	 No
 `undo_backspace` 	 | 	  When enabled, espanso automatically "reverts" an expansion if the user presses the Backspace key afterwards. This is not available on some platform/configurations. 	 | 	 `true`/`false` 	 | 	 `true` 	 | 	 No 
 
-### The following options can be also used inside an [app-specific configuration](../app-specific-configurations):
+### App-specific configurations
+The following options can be used in `$CONFIG/config/default.yml` _and_ in [app-specific configurations](../app-specific-configurations) files:
 
 
 Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -127,7 +127,7 @@ Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default
 `undo_backspace` 	 | 	  When enabled, espanso automatically "reverts" an expansion if the user presses the Backspace key afterwards. This is not available on some platform/configurations. 	 | 	 `true`/`false` 	 | 	 `true` 	 | 	 No 
 
 ### App-specific configurations
-The following options can be used in `$CONFIG/config/default.yml` _and_ in [app-specific configurations](../app-specific-configurations) files:
+The following options can be used in `$CONFIG/config/default.yml` _and_ in [app-specific configurations](../../configuration/app-specific-configurations) files:
 
 
 Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -105,12 +105,13 @@ show_notifications: false
 
 ## Options reference
 
-Here's a list of all the available options. If the value of the `App-specific` column is `Yes`, then the option can be used inside an [App-specific configuration](../app-specific-configurations).
-Otherwise, the option can only be defined inside the `$CONFIG/config/default.yml` file.
+Here are lists of all the available options.
 
-Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default 	 | 	 App-Specific 
---- 	 | 	 --- 	 | 	 --- 	 | 	 --- 	 | 	 ---
-`auto_restart` 	 | 	 If true, instructs the daemon process to restart the worker (and refresh the configuration) after a configuration file change is detected on disk. 	 | 	 `true`/`false` 	 | 	 `true` 	 | 	 No
+### The first list contains options which can _only_ be defined inside the `$CONFIG/config/default.yml` file:
+
+Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default
+--- 	 | 	 --- 	 | 	 --- 	 | 	 ---
+`auto_restart` 	 | 	 If true, instructs the daemon process to restart the worker (and refresh the configuration) after a configuration file change is detected on disk. 	 | 	 `true`/`false` 	 | 	 `true`	 | 	 No
 `backspace_limit` 	 | 	 How many backspace espanso tracks to correct misspelled keywordsMaximum number of backspace presses espanso keeps track of. For example, this is needed to correctly expand even if typos are typed. 	 | 	 `number` 	 | 	5	 | 	 No
 `keyboard_layout` 	 | 	 On Wayland, overrides the auto-detected keyboard configuration (RMLVO) which is used both for the detection and injection process. 	 | 	 An object with fields: `rules`, `model`, `layout`, `variant` and `options` 	 | 	 `{ layout: us }` 	 | 	 No
 `preserve_clipboard` 	 | 	 If true, Espanso will attempt to preserve the previous clipboard content after an expansion has taken place. 	 | 	 `true`/`false` 	 | 	 `true` 	 | 	 No
@@ -123,7 +124,12 @@ Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default 	 | 	 App-Specific
 `win32_keyboard_layout_`<br></br>`cache_interval` 	 | 	 The maximum interval (in milliseconds) for which a keyboard layout can be cached. If switching often between different layouts, you  could lower this amount to avoid the "lost detection" effect described in this [Issue]( https://github.com/espanso/espanso/issues/745). 	 | 	 `number` of milliseconds 	 | 	2000	 | 	 No
 `word_separators` 	 | 	 Chars that when pressed mark the start and end of a word. Examples of this are . or , 	 | 	 A sequence of strings 	 | 	 `[" ", ",", ".", "?", "!", "\r", "\n", "\t", "'", "\"", "\x0c", "(", ")", "[", "]", "{", "}", "<", ">", ":", ";", "\xa0"]` 	 | 	 No
 `undo_backspace` 	 | 	  When enabled, espanso automatically "reverts" an expansion if the user presses the Backspace key afterwards. This is not available on some platform/configurations. 	 | 	 `true`/`false` 	 | 	 `true` 	 | 	 No 
-||||
+
+### The following options can be also used inside an [app-specific configuration](../app-specific-configurations):
+
+
+Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default
+--- 	 | 	 --- 	 | 	 --- 	 | 	 ---
 `apply_patch` 	 | 	 If false, avoid applying the built-in [patches](#patches) to the current config. 	 | 	 `true`/`false` 	 | 	 `true` 	 | 	 Yes
 `backend` 	 | 	  The mechanism used to perform the injection. Espanso can either inject text by simulating keypresses (`Inject` backend) or by using the clipboard (`Clipboard` backend). Both of them have pros and cons, so the `Auto` backend is used by default to automatically choose the most appropriate one based on the situation. If for whatever reason the `Auto` backend is not appropriate, you can change this option to override it. 	 | 	 `clipboard`, `inject` or `auto` 	 | 	 `auto` 	 | 	 Yes
 `clipboard_threshold` 	 | 	 Number of chars after which a match is injected with the clipboard backend instead of the default one. This is done for efficiency reasons, as injecting a long match through separate events becomes slow for long strings. This is only relevant if the backend is set to `Auto`. 	 | 	 `number` 	 | 	100	 | 	 Yes
@@ -133,8 +139,9 @@ Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default 	 | 	 App-Specific
 `evdev_modifier_delay` 	 | 	 Extra delay to apply when injecting modifiers under the EVDEV backend (Wayland). This is useful on Wayland if espanso is injecting seemingly random cased letters, for example "Hi theRE1" instead of "Hi there!". Increase if necessary, decrease to speed up the injection. 	 | 	 `number` of milliseconds 	 | 	10	 | 	 Yes (but on Wayland there is currently no support for App-specific configs)
 `inject_delay` 	 | 	 Number of milliseconds between text injection events. Increase if the target application is missing some characters. 	 | 	 `number` of milliseconds 	 | 	 Between 0 and 1, depending on the platform and application. 	 | 	 Yes
 `key_delay` 	 | 	 Number of milliseconds between key injection events. Increase if the target application is missing some key events. For example, increasing might help if the trigger is not deleted completely. 	 | 	 `number` of milliseconds 	 | 	 Between 0 and 1, depending on platform and application 	 | 	 Yes
-`max_form_height` | Constrains the height of [forms](../../matches/forms). | Number of pixels  | 500 | Yes
-`max_form_width`  | Constrains the width of [forms](../../matches/forms).  | Number of pixels | 700 | Yes
+`max_form_height` | Constrains the height of [forms](../../matches/forms). | `number` of pixels  | 500 | Yes
+`max_form_width`  | Constrains the width of [forms](../../matches/forms).  | `number` of pixels | 700 | Yes
+`max_regex_buffer_size` | **v2.3.0 onwards ONLY**. Length of regex matches | `number` | 30 | Yes
 `paste_shortcut_event_`<br></br>`delay` 	 | 	 Number of milliseconds between keystrokes when simulating the Paste shortcut. For example: CTRL + (wait 5ms) + V + (wait 5ms) + release V + (wait 5ms) + release CTRL. This is needed as sometimes (for example on macOS), without a delay some keystrokes were not registered correctly. 	 | 	 `number` of milliseconds 	 | 	10	 | 	 Yes
 `paste_shortcut` 	 | 	 Customize the keyboard shortcut used to paste an expansion. This should follow this format: CTRL+SHIFT+V. 	 | 	 Keys separated by the `+` plus sign. The available keys are defined [here](https://github.com/espanso/espanso/blob/283b85818b6cc27f1d545337b99effa847b380eb/espanso-inject/src/keys.rs#L237-L323) 	 | 	 Usually `CTRL+V`, but many built-in [patches](#patches) change this behavior 	 | 	 Yes
 `post_form_delay` | Delay (in ms) returning text after closing a form, to allow the target application regain focus. | `number` of milliseconds | 200 | Yes

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -108,7 +108,7 @@ show_notifications: false
 Here are lists of all the available options.
 
 ### `default.yml` only
-The first list contains options which can _only_ be defined inside the `$CONFIG/config/default.yml` file:
+The first list contains global options which can _only_ be defined inside the `$CONFIG/config/default.yml` file:
 
 Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default
 --- 	 | 	 --- 	 | 	 --- 	 | 	 ---

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -127,7 +127,7 @@ Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default
 `undo_backspace` 	 | 	  When enabled, espanso automatically "reverts" an expansion if the user presses the Backspace key afterwards. This is not available on some platform/configurations. 	 | 	 `true`/`false` 	 | 	 `true` 	 | 	 No 
 
 ### App-specific configurations
-The following options can be used in `$CONFIG/config/default.yml` _and_ in [app-specific configurations](../../configuration/app-specific-configurations) files:
+The following options can be used in `$CONFIG/config/default.yml` _and_ in app-specific configuration files:
 
 
 Option 	 | 	 Description 	 | 	 Possible Values 	 | 	 Default

--- a/docs/matches/extensions.mdx
+++ b/docs/matches/extensions.mdx
@@ -21,10 +21,11 @@ For example, the following match will be expanded into `It's 09:30` if triggered
           format: "%H:%M"
 ```
 
-The most important aspect to consider is the `format` parameter,
-which specifies how the date will be rendered.
+The most important aspect to consider is the `format` parameter, which specifies how the date will be rendered.
 
 To see a list of all the possible <b>formatting options</b>, follow this link to refer to the <a href="https://docs.rs/chrono/latest/chrono/format/strftime/index.html">official chrono documentation</a>.
+
+From **Espanso v2.3.0 onwards**, the date extension supports timezones, with a `tz:` parameter, using [IANA timezone names](https://data.iana.org/time-zones/tzdb-2021a/zone1970.tab) (e.g., UTC, America/New_York, Europe/Paris), falling back to local time for invalid timezones.
 
 
 ### Future and past dates

--- a/docs/matches/extensions.mdx
+++ b/docs/matches/extensions.mdx
@@ -25,9 +25,6 @@ The most important aspect to consider is the `format` parameter, which specifies
 
 To see a list of all the possible <b>formatting options</b>, follow this link to refer to the <a href="https://docs.rs/chrono/latest/chrono/format/strftime/index.html">official chrono documentation</a>.
 
-From **Espanso v2.3.0 onwards**, the date extension supports timezones, with a `tz:` parameter, using [IANA timezone names](https://data.iana.org/time-zones/tzdb-2021a/zone1970.tab) (e.g., UTC, America/New_York, Europe/Paris), falling back to local time for invalid timezones.
-
-
 ### Future and past dates
 
 In the previous section, we discussed how to add the _current_ date to your matches, but
@@ -68,16 +65,11 @@ If you need **past dates**, you can specify a _negative offset_ as well. Such as
           offset: -86400
 ```
 
-### Advanced: Localized dates
+### Localized dates
 
-:::info
+#### Locale
 
-Localized dates have been introduced in version v2.1.4-beta, so make sure to have an up-to-date release.
-
-:::
-
-Espanso automatically localizes dates based on your system's country and language,
-but advanced users might want to force a particular locale.
+Espanso automatically localizes dates based on your system's country and language, but advanced users might want to force a particular locale.
 
 For this reason, the Date extension supports the `locale` option to override your system preferences.
 For example, the following snippet always expand to the current date in US format:
@@ -96,6 +88,10 @@ matches:
 
 The `locale` parameter must be specified in the BCP47 format.
 You can find a list of the available locales [here](https://gist.github.com/typpo/b2b828a35e683b9bf8db91b5404f1bd1).
+
+#### Timezones
+
+From **Espanso v2.3.0 onwards**, the date extension also supports timezones, with a `tz:` parameter, using [IANA timezone names](https://data.iana.org/time-zones/tzdb-2021a/zone1970.tab) (e.g., UTC, America/New_York, Europe/Paris), falling back to local time for invalid timezones.
 
 ## Choice Extension
 

--- a/docs/matches/organizing-matches.md
+++ b/docs/matches/organizing-matches.md
@@ -10,7 +10,7 @@ To solve this problem, **Espanso makes it easy to split your matches across mult
 
 ## Splitting your matches
 
-Espanso automatically loads all YAML files placed in the `$CONFIG/match` directory. These files, known as _match sets_, can contain any number of matches and global variables. Older Espanso releases only recognise files suffixed `.yml` but [v2.3.0](https://github.com/espanso/espanso/releases/tag/v2.3.0) onwards enable `.yaml` files to be loaded too.
+Espanso automatically loads all YAML files placed in the `$CONFIG/match` directory. These files, known as _match sets_, can contain any number of matches and global variables. Older Espanso releases only recognise files suffixed `.yml` but **[v2.3.0](https://github.com/espanso/espanso/releases/tag/v2.3.0) onwards** enable `.yaml` files to be loaded too — avoid mixing them, however, to save confusion!
 
 To better understand these concepts, let's see an example:
 

--- a/docs/matches/organizing-matches.md
+++ b/docs/matches/organizing-matches.md
@@ -10,8 +10,8 @@ To solve this problem, **Espanso makes it easy to split your matches across mult
 
 ## Splitting your matches
 
-Espanso automatically loads all YAML files placed in the `$CONFIG/match` directory. These files,
-known as _match sets_, can contain any number of matches and global variables. 
+Espanso automatically loads all YAML files placed in the `$CONFIG/match` directory. These files, known as _match sets_, can contain any number of matches and global variables. Older Espanso releases only recognise files suffixed `.yml` but [v2.3.0](https://github.com/espanso/espanso/releases/tag/v2.3.0) onwards enable `.yaml` files to be loaded too.
+
 To better understand these concepts, let's see an example:
 
 Let's say you would like Espanso to manage your vast collection of email signatures.

--- a/docs/matches/regex-triggers.md
+++ b/docs/matches/regex-triggers.md
@@ -17,6 +17,8 @@ If you don't, these resources can be a good starting point:
 * https://regexone.com/
 * https://www.regular-expressions.info/
 
+Various websites such as https://regex101.com/ enable testing — select the Rust flavor, and remove quotes around the string and unnecessary escapes.
+
 :::
 
 ## Basics
@@ -116,7 +118,7 @@ so that you can use them in replacements and scripts.
 :::caution Named group syntax
 
 Although regular expressions are supported by most programming languages, their syntax can slightly vary 
- between implementations. Espanso uses the [regex](https://docs.rs/regex/1.5.4/regex/)
+ between implementations. Espanso uses the [Rust regex](https://docs.rs/regex/1.5.4/regex/)
 library, which requires you to specify named groups as follows:
 
 ```
@@ -186,11 +188,10 @@ but it's important to keep this in mind when defining matches.
 
 The current regex implementation is subject to a few limitations:
 
-* The maximum length of a "regex match" is set to 30 characters, including the captured named
+* Older versions of Espanso restrict the maximum length of a "regex match" set to 30 characters, including the captured named
 groups. For example, if your regex trigger is `:greet\\((?P<person>.*)\\)` and you type
 `:greet(Bob)`, you've consumed 11 out of 30 characters.
-This limitation has been placed to improve performance, but we are planning to make this
-configurable. Please open an issue on GitHub if this is limiting you :)
+This limitation was placed to improve performance, but from Espanso [v2.3.0](https://github.com/espanso/espanso/releases/tag/v2.3.0) onwards you can override it by adding a `max_regex_buffer_size:` item to a [configuration](../../configuration/basics/) file.
 
-* As explained in the previous sections, Espanso uses a Regex implementation that doesn't support
-all Regex features. For more information, please see the library documentation: https://docs.rs/regex/1.5.4/regex/
+* As explained in the previous sections, Espanso uses the Rust Regex implementation that doesn't support
+all Regex features. For more information, please see the [library documentation](https://docs.rs/regex/1.5.4/regex/).

--- a/docs/matches/regex-triggers.md
+++ b/docs/matches/regex-triggers.md
@@ -191,7 +191,7 @@ The current regex implementation is subject to a few limitations:
 * Older versions of Espanso restrict the maximum length of a "regex match" set to 30 characters, including the captured named
 groups. For example, if your regex trigger is `:greet\\((?P<person>.*)\\)` and you type
 `:greet(Bob)`, you've consumed 11 out of 30 characters.
-This limitation was placed to improve performance, but from Espanso [v2.3.0](https://github.com/espanso/espanso/releases/tag/v2.3.0) onwards you can override it by adding a `max_regex_buffer_size:` item to a [configuration](../../configuration/basics/) file.
+This limitation was placed to improve performance, but from Espanso **[v2.3.0](https://github.com/espanso/espanso/releases/tag/v2.3.0) onwards** you can override it by adding a `max_regex_buffer_size:` item to a [configuration](../../configuration/basics/) file.
 
-* As explained in the previous sections, Espanso uses the Rust Regex implementation that doesn't support
+* As explained in the previous sections, Espanso uses the Rust Regex implementation, which doesn't support
 all Regex features. For more information, please see the [library documentation](https://docs.rs/regex/1.5.4/regex/).

--- a/docs/packages/creating-a-package.md
+++ b/docs/packages/creating-a-package.md
@@ -82,7 +82,8 @@ Edit the `_manifest.yml` file to customize the package metadata:
   * `description` should contain a short description of your package.
   * `version` contains the version of your package. We suggest to keep it at `0.1.0` for new packages, and this number *must* match that in the package path above.
   * `author` contains the author name.
-  * `tags` contains a list of keywords
+  * `tags` contains a list of keywords.
+  * `homepage` your homepage or GitHub repo, for example.
 
 There are also other possible fields, please visit the [Package Specification](../package-specification)
 if you are interested.
@@ -96,6 +97,7 @@ description: A simple package to show how to create your own one!
 version: 0.1.0
 author: Federico Terzi
 tags: ["sample". "words"]
+homepage: "https://github.com/federico-terzi/espanso-hub"
 ```
 
 ### Customizing the snippets
@@ -130,14 +132,14 @@ Once your package is ready, we can finally publish it on the Hub, awesome!
 
 :::`.yml` or `.yaml`?
 
-Whilst Espanso  [v2.3.0](https://github.com/espanso/espanso/releases/tag/v2.3.0) onwards enables `.yaml` suffixed files to be loaded, please stick to `.yml`  files in packages for now, to enable use with the previous versions.
+Whilst Espanso  **[v2.3.0](https://github.com/espanso/espanso/releases/tag/v2.3.0) onwards** enables `.yaml` suffixed files to be loaded, please stick to `.yml`  files in packages for now, to enable use with the previous versions.
 
 :::
 
 After committing your changes and pushing it to your forked version of the Hub, you'll need to **open a pull request** on the [espanso/hub repository](https://github.com/espanso/hub).
 
 
-At that point, the Espanso team will review it and, once verified, your package will be published! Please be prepared to engage with the reviewers, who may suggest changes to correct errors and make improvements.
+At that point, the Espanso team will review it and, once verified, your package will be published! Please be prepared to engage with the reviewers, who may suggest improvements, or changes to correct errors.
 
 ## Publish on a GIT repository (private or public) 
 

--- a/docs/packages/creating-a-package.md
+++ b/docs/packages/creating-a-package.md
@@ -130,7 +130,7 @@ is to show how to create new Espanso packages!
 
 Once your package is ready, we can finally publish it on the Hub, awesome!
 
-:::.yml or .yaml?
+:::note `.yml` or `.yaml`?
 
 Whilst Espanso  **[v2.3.0](https://github.com/espanso/espanso/releases/tag/v2.3.0) onwards** enables `.yaml` suffixed files to be loaded, please stick to `.yml`  files in packages for now, to enable use with the previous versions.
 

--- a/docs/packages/creating-a-package.md
+++ b/docs/packages/creating-a-package.md
@@ -128,9 +128,16 @@ is to show how to create new Espanso packages!
 
 Once your package is ready, we can finally publish it on the Hub, awesome!
 
+:::`.yml` or `.yaml`?
+
+Whilst Espanso  [v2.3.0](https://github.com/espanso/espanso/releases/tag/v2.3.0) onwards enables `.yaml` suffixed files to be loaded, please stick to `.yml`  files in packages for now, to enable use with the previous versions.
+
+:::
+
 After committing your changes and pushing it to your forked version of the Hub, you'll need to **open a pull request** on the [espanso/hub repository](https://github.com/espanso/hub).
 
-At that point, the Espanso team will review it and, once verified, your package will be published!
+
+At that point, the Espanso team will review it and, once verified, your package will be published! Please be prepared to engage with the reviewers, who may suggest changes to correct errors and make improvements.
 
 ## Publish on a GIT repository (private or public) 
 

--- a/docs/packages/creating-a-package.md
+++ b/docs/packages/creating-a-package.md
@@ -130,7 +130,7 @@ is to show how to create new Espanso packages!
 
 Once your package is ready, we can finally publish it on the Hub, awesome!
 
-:::`.yml` or `.yaml`?
+:::.yml or .yaml?
 
 Whilst Espanso  **[v2.3.0](https://github.com/espanso/espanso/releases/tag/v2.3.0) onwards** enables `.yaml` suffixed files to be loaded, please stick to `.yml`  files in packages for now, to enable use with the previous versions.
 


### PR DESCRIPTION
'options.md' - add `max_regex_buffer_size:` and reformat the options lists
`extensions.mdx` - add `tz:` for v2.3.0
`organizing-matches.md` - mention `.yaml` files - new `max_regex_buffer_size:` option and some minor changes
`creating-a-package.md` - encourage `.yml` files and engagement wit reviewers
and a few tweaks